### PR TITLE
[FNUI-3236] Swifty Library Hang Risk optimisation

### DIFF
--- a/Sources/Inspector/SwiftyInspector.swift
+++ b/Sources/Inspector/SwiftyInspector.swift
@@ -37,9 +37,16 @@ public struct NetworkResourceMetric {
 @objc public final class SwiftyInspector: UITableViewController {
     
     /**
-     The shared instance of the Swifty Inspector.
+     The shared instance of the Swifty Inspector. 
+     Creating the shared instance on the Main Thread, as SwiftyInspector is inherited by UITableViewController, and it hangs the screen loading if called from other thread.
     */
-    @objc public static let shared = SwiftyInspector()
+    @objc public static let shared: SwiftyInspector = {
+        var instance: SwiftyInspector!
+        DispatchQueue.main.sync {
+            instance = SwiftyInspector()
+        }
+        return instance
+    }()
     
     /**
      Get the Swifty Inspector's View Controller.

--- a/Sources/Inspector/SwiftyInspector.swift
+++ b/Sources/Inspector/SwiftyInspector.swift
@@ -41,7 +41,7 @@ public struct NetworkResourceMetric {
      Creating the shared instance on the Main Thread, as SwiftyInspector is inherited by UITableViewController, and it hangs the screen loading if called from other thread.
     */
     @objc public static let shared: SwiftyInspector = {
-        if Thread.isMainThread {
+        if Thread.current.isMainThread {
             return SwiftyInspector()
         } else {
             return DispatchQueue.main.sync {

--- a/Sources/Inspector/SwiftyInspector.swift
+++ b/Sources/Inspector/SwiftyInspector.swift
@@ -41,11 +41,13 @@ public struct NetworkResourceMetric {
      Creating the shared instance on the Main Thread, as SwiftyInspector is inherited by UITableViewController, and it hangs the screen loading if called from other thread.
     */
     @objc public static let shared: SwiftyInspector = {
-        var instance: SwiftyInspector!
-        DispatchQueue.main.sync {
-            instance = SwiftyInspector()
+        if Thread.isMainThread {
+            return SwiftyInspector()
+        } else {
+            return DispatchQueue.main.sync {
+                SwiftyInspector()
+            }
         }
-        return instance
     }()
     
     /**


### PR DESCRIPTION
The shared instance is getting accessed from the background thread, which raises the Main Thread hang issue, as SwiftInspector is inherited from UITableViewController. So, UI should be called on Main Thread to prevent the hang risk issue. 